### PR TITLE
fix/新規登録後のパス指定

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -53,8 +53,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  def after_sign_up_path_for(resource)
-    user_session_path(resource)
+  def after_sign_in_path_for(resource)
+    authenticated_root_path
   end
 
   # The path used after sign up for inactive accounts.


### PR DESCRIPTION
## 概要
新規登録後にrootパスに行くように設定しました。

## 修正内容

## 影響範囲

## レビュー観点

## 補足
